### PR TITLE
Add jets to SSL evaluation

### DIFF
--- a/mlpf/jet_utils.py
+++ b/mlpf/jet_utils.py
@@ -1,0 +1,103 @@
+import numpy as np
+import numba
+import awkward
+import vector
+
+
+@numba.njit
+def deltaphi(phi1, phi2):
+    return np.fmod(phi1 - phi2 + np.pi, 2 * np.pi) - np.pi
+
+
+@numba.njit
+def deltar(eta1, phi1, eta2, phi2):
+    deta = np.abs(eta1 - eta2)
+    dphi = deltaphi(phi1, phi2)
+    return np.sqrt(deta**2 + dphi**2)
+
+
+@numba.njit
+def match_jets(jets1, jets2, deltaR_cut):
+    iev = len(jets1)
+    jet_inds_1_ev = []
+    jet_inds_2_ev = []
+    for ev in range(iev):
+        j1 = jets1[ev]
+        j2 = jets2[ev]
+
+        jet_inds_1 = []
+        jet_inds_2 = []
+        for ij1 in range(len(j1)):
+            drs = np.zeros(len(j2), dtype=np.float64)
+            for ij2 in range(len(j2)):
+                eta1 = j1.eta[ij1]
+                eta2 = j2.eta[ij2]
+                phi1 = j1.phi[ij1]
+                phi2 = j2.phi[ij2]
+
+                # Workaround for https://github.com/scikit-hep/vector/issues/303
+                # dr = j1[ij1].deltaR(j2[ij2])
+                dr = deltar(eta1, phi1, eta2, phi2)
+                drs[ij2] = dr
+            if len(drs) > 0:
+                min_idx_dr = np.argmin(drs)
+                if drs[min_idx_dr] < deltaR_cut:
+                    jet_inds_1.append(ij1)
+                    jet_inds_2.append(min_idx_dr)
+        jet_inds_1_ev.append(jet_inds_1)
+        jet_inds_2_ev.append(jet_inds_2)
+    return jet_inds_1_ev, jet_inds_2_ev
+
+
+def squeeze_if_one(arr):
+    if arr.shape[-1] == 1:
+        return np.squeeze(arr, axis=-1)
+    else:
+        return arr
+
+
+def build_dummy_array(num, dtype=np.int64):
+    return awkward.Array(
+        awkward.contents.ListOffsetArray(
+            awkward.index.Index64(np.zeros(num + 1, dtype=np.int64)),
+            awkward.from_numpy(np.array([], dtype=dtype), highlevel=False),
+        )
+    )
+
+
+def match_two_jet_collections(jets_coll, name1, name2, jet_match_dr):
+    num_events = len(jets_coll[name1])
+    vec1 = vector.awk(
+        awkward.zip(
+            {
+                "pt": jets_coll[name1].pt,
+                "eta": jets_coll[name1].eta,
+                "phi": jets_coll[name1].phi,
+                "energy": jets_coll[name1].energy,
+            }
+        )
+    )
+    vec2 = vector.awk(
+        awkward.zip(
+            {
+                "pt": jets_coll[name2].pt,
+                "eta": jets_coll[name2].eta,
+                "phi": jets_coll[name2].phi,
+                "energy": jets_coll[name2].energy,
+            }
+        )
+    )
+    ret = match_jets(vec1, vec2, jet_match_dr)
+    j1_idx = awkward.from_iter(ret[0])
+    j2_idx = awkward.from_iter(ret[1])
+
+    num_jets = len(awkward.flatten(j1_idx))
+
+    # In case there are no jets matched, create dummy array to ensure correct types
+    if num_jets > 0:
+        c1_to_c2 = awkward.Array({name1: j1_idx, name2: j2_idx})
+    else:
+        dummy = build_dummy_array(num_events)
+        c1_to_c2 = awkward.Array({name1: dummy, name2: dummy})
+
+    return c1_to_c2

--- a/mlpf/plotting/plot_utils.py
+++ b/mlpf/plotting/plot_utils.py
@@ -168,9 +168,10 @@ def load_eval_data(path, max_files=None):
             yvals["{}_{}".format(typ, k)] = data["particles"][typ][k]
 
     # Get the classification output as a class ID
-    yvals["gen_cls_id"] = np.argmax(yvals["gen_cls"], axis=-1)
-    yvals["cand_cls_id"] = np.argmax(yvals["cand_cls"], axis=-1)
-    yvals["pred_cls_id"] = np.argmax(yvals["pred_cls"], axis=-1)
+    if "gen_cls_id" not in yvals.keys():
+        yvals["gen_cls_id"] = np.argmax(yvals["gen_cls"], axis=-1)
+        yvals["cand_cls_id"] = np.argmax(yvals["cand_cls"], axis=-1)
+        yvals["pred_cls_id"] = np.argmax(yvals["pred_cls"], axis=-1)
 
     for typ in ["gen", "cand", "pred"]:
 
@@ -185,7 +186,7 @@ def load_eval_data(path, max_files=None):
             yvals["jets_{}_{}".format(typ, k)] = getattr(jetvec, k)
 
     for typ in ["gen", "cand", "pred"]:
-        for val in ["pt", "eta", "sin_phi", "cos_phi", "charge", "energy"]:
+        for val in ["pt", "eta", "sin_phi", "cos_phi", "energy"]:
             yvals["{}_{}".format(typ, val)] = yvals["{}_{}".format(typ, val)] * (yvals["{}_cls_id".format(typ)] != 0)
 
     yvals.update(compute_jet_ratio(data, yvals))

--- a/mlpf/pyg_ssl/PFGraphDataset.py
+++ b/mlpf/pyg_ssl/PFGraphDataset.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import os.path as osp
 from glob import glob
+import tqdm
 
 import awkward as ak
 import numpy as np
@@ -35,6 +36,11 @@ def generate_examples(files):
 
             X1 = ak.to_numpy(X_track[iev])
             X2 = ak.to_numpy(X_cluster[iev])
+
+            X1[np.isnan(X1)] = 0.0
+            X1[np.isinf(X1)] = 0.0
+            X2[np.isnan(X2)] = 0.0
+            X2[np.isinf(X2)] = 0.0
 
             if len(X1) == 0 or len(X2) == 0:
                 continue
@@ -98,7 +104,7 @@ class PFGraphDataset(Dataset):
 
     @property
     def raw_file_names(self):
-        raw_list = glob(osp.join(self.raw_dir, "*"))
+        raw_list = glob(osp.join(self.raw_dir, "*.parquet"))
         print("PFGraphDataset nfiles={}".format(len(raw_list)))
         return sorted([raw_path.replace(self.raw_dir, ".") for raw_path in raw_list])
 
@@ -153,7 +159,7 @@ class PFGraphDataset(Dataset):
 
     def process_multiple_files(self, filenames, idx_file):
         datas = []
-        for fn in filenames:
+        for fn in tqdm.tqdm(filenames):
             x = self.process_single_file(fn)
             if x is None:
                 continue
@@ -227,3 +233,4 @@ if __name__ == "__main__":
         pfgraphdataset._processed_dir = args.processed_dir
 
     pfgraphdataset.process_parallel(args.num_files_merge, args.num_proc)
+    # pfgraphdataset.process(args.num_files_merge)

--- a/mlpf/pyg_ssl/evaluate.py
+++ b/mlpf/pyg_ssl/evaluate.py
@@ -7,8 +7,14 @@ import sklearn
 import sklearn.metrics
 import torch
 import torch_geometric
+import vector
+import fastjet
+import awkward
+import tqdm
 
 from .utils import CLASS_NAMES_CLIC_LATEX, NUM_CLASSES, combine_PFelements, distinguish_PFelements
+
+from jet_utils import match_two_jet_collections, build_dummy_array
 
 matplotlib.use("Agg")
 
@@ -24,7 +30,25 @@ CLASS_TO_ID = {
 }
 
 
+def particle_array_to_awkward(batch_ids, arr_id, arr_p4):
+    ret = {
+        "cls_id": arr_id,
+        "pt": arr_p4[:, 1],
+        "eta": arr_p4[:, 2],
+        "phi": arr_p4[:, 3],
+        "energy": arr_p4[:, 4],
+    }
+    ret["sin_phi"] = np.sin(ret["phi"])
+    ret["cos_phi"] = np.cos(ret["phi"])
+    ret = awkward.from_iter([{k: ret[k][batch_ids == b] for k in ret.keys()} for b in np.unique(batch_ids)])
+    return ret
+
+
 def evaluate(device, encoder, decoder, mlpf, batch_size_mlpf, mode, outpath, data_, save_as_):
+
+    jetdef = fastjet.JetDefinition(fastjet.antikt_algorithm, 0.4)
+    jet_pt = 5.0
+    jet_match_dr = 0.1
 
     npred_, ngen_, ncand_, = (
         {},
@@ -43,9 +67,13 @@ def evaluate(device, encoder, decoder, mlpf, batch_size_mlpf, mode, outpath, dat
         for class_ in CLASS_TO_ID.keys():
             npred[class_], ngen[class_], ncand[class_] = [], [], []
 
+        mlpf.eval()
+        encoder.eval()
+        decoder.eval()
+
         conf_matrix = np.zeros((6, 6))
         with torch.no_grad():
-            for i, batch in enumerate(test_loader):
+            for i, batch in tqdm.tqdm(enumerate(test_loader), total=len(test_loader)):
                 print(f"making predictions: {i+1}/{len(test_loader)}")
 
                 if mode == "ssl":
@@ -65,11 +93,92 @@ def evaluate(device, encoder, decoder, mlpf, batch_size_mlpf, mode, outpath, dat
                     event = batch
 
                 # make mlpf forward pass
-                pred_ids_one_hot = mlpf(event.to(device))
+                pred_ids_one_hot, pred_momentum, pred_charge = mlpf(event.to(device))
 
                 pred_ids = torch.argmax(pred_ids_one_hot, axis=1)
                 target_ids = event.ygen_id
                 cand_ids = event.ycand_id
+
+                batch_ids = event.batch.cpu().numpy()
+                awkvals = {
+                    "gen": particle_array_to_awkward(batch_ids, target_ids.cpu().numpy(), event.ygen.cpu().numpy()),
+                    "cand": particle_array_to_awkward(batch_ids, cand_ids.cpu().numpy(), event.ycand.cpu().numpy()),
+                    "pred": particle_array_to_awkward(
+                        batch_ids, pred_ids.cpu().numpy(), torch.cat([pred_charge, pred_momentum], axis=-1).cpu().numpy()
+                    ),
+                }
+
+                gen_p4 = []
+                gen_cls = []
+                cand_p4 = []
+                cand_cls = []
+                pred_p4 = []
+                pred_cls = []
+                Xs = []
+                for ibatch in np.unique(event.batch.cpu().numpy()):
+                    msk_batch = event.batch == ibatch
+                    msk_gen = target_ids[msk_batch] != 0
+                    msk_cand = cand_ids[msk_batch] != 0
+                    msk_pred = pred_ids[msk_batch] != 0
+
+                    Xs.append(event.x[msk_batch].cpu().numpy())
+
+                    gen_p4.append(event.ygen[msk_batch, 1:][msk_gen])
+                    gen_cls.append(target_ids[msk_batch][msk_gen])
+
+                    cand_p4.append(event.ycand[msk_batch, 1:][msk_cand])
+                    cand_cls.append(cand_ids[msk_batch][msk_cand])
+
+                    pred_p4.append(pred_momentum[msk_batch, :][msk_pred])
+                    pred_cls.append(pred_ids[msk_batch][msk_pred])
+
+                Xs = awkward.from_iter(Xs)
+
+                gen_p4 = awkward.from_iter(gen_p4)
+                gen_cls = awkward.from_iter(gen_cls)
+                gen_p4 = vector.awk(
+                    awkward.zip(
+                        {"pt": gen_p4[:, :, 0], "eta": gen_p4[:, :, 1], "phi": gen_p4[:, :, 2], "e": gen_p4[:, :, 3]}
+                    )
+                )
+
+                cand_p4 = awkward.from_iter(cand_p4)
+                cand_cls = awkward.from_iter(cand_cls)
+                cand_p4 = vector.awk(
+                    awkward.zip(
+                        {"pt": cand_p4[:, :, 0], "eta": cand_p4[:, :, 1], "phi": cand_p4[:, :, 2], "e": cand_p4[:, :, 3]}
+                    )
+                )
+
+                # in case of no predicted particles in the batch
+                if torch.sum(pred_ids != 0) == 0:
+                    pt = build_dummy_array(len(pred_p4), np.float64)
+                    eta = build_dummy_array(len(pred_p4), np.float64)
+                    phi = build_dummy_array(len(pred_p4), np.float64)
+                    pred_cls = build_dummy_array(len(pred_p4), np.float64)
+                    energy = build_dummy_array(len(pred_p4), np.float64)
+                    pred_p4 = vector.awk(awkward.zip({"pt": pt, "eta": eta, "phi": phi, "e": energy}))
+                else:
+                    pred_p4 = awkward.from_iter(pred_p4)
+                    pred_cls = awkward.from_iter(pred_cls)
+                    pred_p4 = vector.awk(
+                        awkward.zip(
+                            {"pt": pred_p4[:, :, 0], "eta": pred_p4[:, :, 1], "phi": pred_p4[:, :, 2], "e": pred_p4[:, :, 3]}
+                        )
+                    )
+
+                jets_coll = {}
+
+                cluster1 = fastjet.ClusterSequence(awkward.Array(gen_p4.to_xyzt()), jetdef)
+                jets_coll["gen"] = cluster1.inclusive_jets(min_pt=jet_pt)
+                cluster2 = fastjet.ClusterSequence(awkward.Array(cand_p4.to_xyzt()), jetdef)
+                jets_coll["cand"] = cluster2.inclusive_jets(min_pt=jet_pt)
+                cluster3 = fastjet.ClusterSequence(awkward.Array(pred_p4.to_xyzt()), jetdef)
+                jets_coll["pred"] = cluster3.inclusive_jets(min_pt=jet_pt)
+
+                gen_to_pred = match_two_jet_collections(jets_coll, "gen", "pred", jet_match_dr)
+                gen_to_cand = match_two_jet_collections(jets_coll, "gen", "cand", jet_match_dr)
+                matched_jets = awkward.Array({"gen_to_pred": gen_to_pred, "gen_to_cand": gen_to_cand})
 
                 conf_matrix += sklearn.metrics.confusion_matrix(
                     target_ids.detach().cpu(),
@@ -77,7 +186,18 @@ def evaluate(device, encoder, decoder, mlpf, batch_size_mlpf, mode, outpath, dat
                     labels=range(NUM_CLASSES),
                 )
 
-                # for multiplicity plots, must reduce the batch dimension
+                awkward.to_parquet(
+                    awkward.Array(
+                        {
+                            "inputs": Xs,
+                            "particles": awkvals,
+                            "jets": jets_coll,
+                            "matched_jets": matched_jets,
+                        }
+                    ),
+                    "{}/pred_{}_{}.parquet".format(outpath, save_as_[j], i),
+                )
+
                 for batch_index in range(batch_size_mlpf):
                     # unpack the batch
                     pred = pred_ids[event.batch == batch_index]

--- a/mlpf/pyg_ssl/utils.py
+++ b/mlpf/pyg_ssl/utils.py
@@ -279,7 +279,7 @@ def data_split(dataset, data_split_mode):
     elif data_split_mode == "mix":
 
         data = []
-        for sample in os.listdir(dataset):
+        for sample in ["p8_ee_qcd_ecm365", "p8_ee_tt_ecm365"]:
 
             files = glob.glob(f"{dataset}/{sample}/processed/*")
             data_per_sample = []

--- a/mlpf/tfmodel/model_setup.py
+++ b/mlpf/tfmodel/model_setup.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import awkward
 import fastjet
-import numba
 import numpy as np
 import tensorflow as tf
 import tensorflow_addons as tfa
@@ -30,6 +29,8 @@ from tfmodel.datasets.BaseDatasetFactory import unpack_target
 from tqdm import tqdm
 
 from .model import PFNetDense, PFNetTransformer
+
+from jet_utils import match_two_jet_collections, build_dummy_array, squeeze_if_one
 
 
 class ModelOptimizerCheckpoint(tf.keras.callbacks.ModelCheckpoint):
@@ -308,105 +309,6 @@ def make_transformer(config, dtype):
         **kwargs
     )
     return model
-
-
-@numba.njit
-def deltaphi(phi1, phi2):
-    return np.fmod(phi1 - phi2 + np.pi, 2 * np.pi) - np.pi
-
-
-@numba.njit
-def deltar(eta1, phi1, eta2, phi2):
-    deta = np.abs(eta1 - eta2)
-    dphi = deltaphi(phi1, phi2)
-    return np.sqrt(deta**2 + dphi**2)
-
-
-@numba.njit
-def match_jets(jets1, jets2, deltaR_cut):
-    iev = len(jets1)
-    jet_inds_1_ev = []
-    jet_inds_2_ev = []
-    for ev in range(iev):
-        j1 = jets1[ev]
-        j2 = jets2[ev]
-
-        jet_inds_1 = []
-        jet_inds_2 = []
-        for ij1 in range(len(j1)):
-            drs = np.zeros(len(j2), dtype=np.float64)
-            for ij2 in range(len(j2)):
-                eta1 = j1.eta[ij1]
-                eta2 = j2.eta[ij2]
-                phi1 = j1.phi[ij1]
-                phi2 = j2.phi[ij2]
-
-                # Workaround for https://github.com/scikit-hep/vector/issues/303
-                # dr = j1[ij1].deltaR(j2[ij2])
-                dr = deltar(eta1, phi1, eta2, phi2)
-                drs[ij2] = dr
-            if len(drs) > 0:
-                min_idx_dr = np.argmin(drs)
-                if drs[min_idx_dr] < deltaR_cut:
-                    jet_inds_1.append(ij1)
-                    jet_inds_2.append(min_idx_dr)
-        jet_inds_1_ev.append(jet_inds_1)
-        jet_inds_2_ev.append(jet_inds_2)
-    return jet_inds_1_ev, jet_inds_2_ev
-
-
-def squeeze_if_one(arr):
-    if arr.shape[-1] == 1:
-        return np.squeeze(arr, axis=-1)
-    else:
-        return arr
-
-
-def build_dummy_array(num, dtype=np.int64):
-    return awkward.Array(
-        awkward.contents.ListOffsetArray(
-            awkward.index.Index64(np.zeros(num + 1, dtype=np.int64)),
-            awkward.from_numpy(np.array([], dtype=dtype), highlevel=False),
-        )
-    )
-
-
-def match_two_jet_collections(jets_coll, name1, name2, jet_match_dr):
-    num_events = len(jets_coll[name1])
-    vec1 = vector.awk(
-        awkward.zip(
-            {
-                "pt": jets_coll[name1].pt,
-                "eta": jets_coll[name1].eta,
-                "phi": jets_coll[name1].phi,
-                "energy": jets_coll[name1].energy,
-            }
-        )
-    )
-    vec2 = vector.awk(
-        awkward.zip(
-            {
-                "pt": jets_coll[name2].pt,
-                "eta": jets_coll[name2].eta,
-                "phi": jets_coll[name2].phi,
-                "energy": jets_coll[name2].energy,
-            }
-        )
-    )
-    ret = match_jets(vec1, vec2, jet_match_dr)
-    j1_idx = awkward.from_iter(ret[0])
-    j2_idx = awkward.from_iter(ret[1])
-
-    num_jets = len(awkward.flatten(j1_idx))
-
-    # In case there are no jets matched, create dummy array to ensure correct types
-    if num_jets > 0:
-        c1_to_c2 = awkward.Array({name1: j1_idx, name2: j2_idx})
-    else:
-        dummy = build_dummy_array(num_events)
-        c1_to_c2 = awkward.Array({name1: dummy, name2: dummy})
-
-    return c1_to_c2
 
 
 # Given a model, evaluates it on each batch of the validation dataset

--- a/scripts/local_test_ssl_pipeline.sh
+++ b/scripts/local_test_ssl_pipeline.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# first go to the particleflow/ directory
-cd ../
-
 # download and process the datasets under particleflow/data/clic_edm4hep/
 rm -Rf data/clic_edm4hep/p8_ee_tt_ecm365
 rm -Rf data/clic_edm4hep/p8_ee_qcd_ecm365/


### PR DESCRIPTION
- add jet clustering to SSL evaluation
- save evaluation outputs to .parquet files, compatible with other plottings scripts
- limit `mix` training to ttbar and qcd for the moment
- ensure tests run, tested in https://github.com/jpata/particleflow/actions/runs/3999334995