### PR TITLE
Fix NumPy warning in eta calculation

### DIFF
--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -468,8 +468,7 @@ def cluster_to_features(prop_data, hit_features, hit_to_cluster, iev):
     ret["sigma_z"] = np.array(cl_sigma_z)
 
     tt = awkward.to_numpy(np.tan(ret["iTheta"] / 2.0))
-    eta = awkward.to_numpy(-np.log(tt, where=tt > 0))
-    eta[tt <= 0] = 0.0
+    eta = awkward.to_numpy(-np.log(tt, where=(tt > 0), out=np.zeros_like(tt)))
     ret["eta"] = eta
 
     costheta = np.cos(ret["iTheta"])


### PR DESCRIPTION
NumPy >= 2.4 warns when where is used without out because masked entries may contain uninitialized memory.
In the eta calculation, these entries were overwritten immediately afterward, so this was not causing an issue currently. However, setting out explicitly makes the behavior safe and avoids relying on the subsequent overwrite.